### PR TITLE
Add Github link

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -37,6 +37,11 @@ const siteConfig = {
         src: 'img/logo.svg',
       },
       links: [
+        {
+          href: 'https://github.com/paracordjs/paracord',
+          label: 'GitHub',
+          position: 'right',
+        },
         {to: 'docs/simple_usage', label: 'Get Started' },
       ],
     },


### PR DESCRIPTION
### Summary
Just a simple change for a link to Github project page.

### How it looks like
![Screenshot_20200725_185044](https://user-images.githubusercontent.com/8044172/88458480-c351ce00-cea7-11ea-8f77-655fb051fb5b.png)
